### PR TITLE
check if the routeNotificationForSmsGlobal exists before calling it

### DIFF
--- a/src/SmsGlobalChannel.php
+++ b/src/SmsGlobalChannel.php
@@ -23,10 +23,9 @@ class SmsGlobalChannel
      */
     public function send($notifiable, Notification $notification): void
     {
-        if (! $notifiable->routeNotificationFor('sms_global', $notification)) {
+        if (method_exists($notifiable, 'routeNotificationForSmsGlobal') && !$notifiable->routeNotificationFor('sms_global', $notification)) {
             return;
         }
-
         /* @var SmsGlobalMessage $message */
         $message = $notification->toSmsGlobal($notifiable);
 


### PR DESCRIPTION
This pull request makes a small but important change to the notification routing logic in the `SmsGlobalChannel`. It adds a check to ensure that the `routeNotificationForSmsGlobal` method exists on the `$notifiable` object before attempting to use the notification route.

- Improved notification routing:
  * In `src/SmsGlobalChannel.php`, updated the `send` method to check for the existence of the `routeNotificationForSmsGlobal` method before calling `routeNotificationFor('sms_global', $notification)`. This prevents potential errors if the method does not exist on the notifiable object.[Copilot is generating a summary...]